### PR TITLE
Update zookeeper dependency scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,7 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper-version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
Since zookeeper is not bundled with grizzly-memcached,
the scope for this dependency can be changed from default
"compile" to "provided"